### PR TITLE
 Expand email schedule to 3 days per week and add new BCC contacts

### DIFF
--- a/.github/workflows/send-daily-emails.yml
+++ b/.github/workflows/send-daily-emails.yml
@@ -1,9 +1,9 @@
-name: Government Road Complaint Emails (Mon/Fri)
+name: Government Road Complaint Emails (Mon/Wed/Fri)
 
 on:
   schedule:
-    # Runs Monday, Friday at 4:00 AM UTC (9:00 AM Pakistan Time)
-    - cron: "0 4 * * 1,5"
+    # Runs Monday, Wednesday, Friday at 4:00 AM UTC (9:00 AM Pakistan Time)
+    - cron: "0 4 * * 1,3,5"
   workflow_dispatch: # Keep for manual testing
 
 jobs:
@@ -56,6 +56,6 @@ jobs:
         if: always()
         run: |
           echo "📧 Government road complaint emails workflow completed at $(date +'%Y-%m-%d %H:%M:%S')"
-          echo "⏰ Next scheduled send: Monday or Friday at 4:00 AM Pakistan time"
-          echo "📅 Schedule: Monday (English) and Friday (Urdu) emails only"
+          echo "⏰ Next scheduled send: Monday, Wednesday, or Friday at 4:00 AM Pakistan time"
+          echo "📅 Schedule: Monday (English), Wednesday (English), and Friday (Urdu) emails only"
           echo "📊 Status: ${{ job.status }}"

--- a/src/config.py
+++ b/src/config.py
@@ -49,6 +49,9 @@ CC_EMAILS = [
 BCC_EMAILS = [
     # Backup and tracking emails
     "sultan512@gmail.com",
+    "sukhan@alphabold.com",
+    "fatima.umer15@gmail.com",
+    "ajbutt48@gmail.com",
     "Mussabsalman12@gmail.com", # AVG Phase 1 Resident
     # "sultan18kh@gmail.com",
     # "humakhan1127@gmail.com",
@@ -1192,9 +1195,9 @@ EMAIL_SERVICES = [
 
 # GitHub Actions Configuration
 GITHUB_ACTIONS_CONFIG = {
-    "cron_schedule": "0 4 * * 1,5",  # Mon, Fri at 4:00 AM UTC (9:00 AM Pakistan time)
+    "cron_schedule": "0 4 * * 1,3,5",  # Mon, Wed, Fri at 4:00 AM UTC (9:00 AM Pakistan time)
     "python_version": "3.11",
-    "workflow_name": "Government Road Complaint Emails (Mon/Fri)",
+    "workflow_name": "Government Road Complaint Emails (Mon/Wed/Fri)",
 }
 
 # Monitoring Configuration

--- a/src/config.py
+++ b/src/config.py
@@ -48,11 +48,12 @@ CC_EMAILS = [
 # BCC (Blind Carbon Copy) Emails - for tracking and backup
 BCC_EMAILS = [
     # Backup and tracking emails
-    "sultan512@gmail.com",
-    "sukhan@alphabold.com",
+    "sultan512@gmail.com", # Secondary Test Email
+    "sukhan@alphabold.com", # Outlook Test Email
     "fatima.umer15@gmail.com",
     "ajbutt48@gmail.com",
     "Mussabsalman12@gmail.com", # AVG Phase 1 Resident
+    "hssn.wasim3334@gmail.com", # AVG Phase 1 Resident & Colleague
     # "sultan18kh@gmail.com",
     # "humakhan1127@gmail.com",
 ]

--- a/src/send_single_email.py
+++ b/src/send_single_email.py
@@ -531,17 +531,20 @@ class GovernmentEmailSender:
         return self.email_services[service_index]
 
     def select_template(self):
-        """Select template based on day of week for Monday/Friday rotation"""
+        """Select template based on day of week for Monday/Wednesday/Friday rotation"""
         if not self.template_config["template_rotation"]:
             return self.template_config["default_template"]
 
         # Get current day of week (0=Monday, 6=Sunday in isoweekday)
         current_day = self.get_current_time_pakistan().isoweekday()
 
-        # Monday = 1, Friday = 5
+        # Monday = 1, Wednesday = 3, Friday = 5
         if current_day == 1:  # Monday
             # Use template 1 or 3 (English) for Monday
-            return random.choice([1, 3])
+            return 1
+        elif current_day == 3:  # Wednesday
+            # Use template 1 (English) for Wednesday
+            return 3
         elif current_day == 5:  # Friday
             # Use template 2 (Urdu) for Friday
             return 2
@@ -855,15 +858,16 @@ def main():
             success = sender.send_daily_emails()
             return success
         else:
-            # Local mode - schedule for Monday and Friday only
-            print("💻 Running in local mode - scheduling emails for Monday and Friday")
+            # Local mode - schedule for Monday, Wednesday, and Friday only
+            print("💻 Running in local mode - scheduling emails for Monday, Wednesday, and Friday")
             schedule.every().monday.at("09:00").do(sender.send_daily_emails)
+            schedule.every().wednesday.at("09:00").do(sender.send_daily_emails)
             schedule.every().friday.at("09:00").do(sender.send_daily_emails)
 
             print(
-                "📅 Scheduled: Emails will be sent every Monday and Friday at 9:00 AM PKT"
+                "📅 Scheduled: Emails will be sent every Monday, Wednesday, and Friday at 9:00 AM PKT"
             )
-            print("⏸️  Wednesday emails have been disabled as requested")
+            print("📧 Three emails per week for better advocacy coverage")
 
             while True:
                 schedule.run_pending()

--- a/src/test_email.py
+++ b/src/test_email.py
@@ -688,7 +688,7 @@ def test_template_logic():
     """Test template selection logic"""
     print("\n📋 Testing template selection logic...")
     
-    # Test Monday/Friday schedule
+    # Test Monday/Wednesday/Friday schedule
     day_names = {1: "Monday", 2: "Tuesday", 3: "Wednesday", 4: "Thursday", 
                  5: "Friday", 6: "Saturday", 7: "Sunday"}
     
@@ -700,7 +700,10 @@ def test_template_logic():
 
     for day in range(1, 8):
         if day == 1:  # Monday
-            template_type = random.choice([1, 3])
+            template_type = 1
+            schedule_status = "📧 EMAIL DAY"
+        elif day == 3:  # Wednesday
+            template_type = 3
             schedule_status = "📧 EMAIL DAY"
         elif day == 5:  # Friday
             template_type = 2


### PR DESCRIPTION
- Update schedule from Mon/Fri to Mon/Wed/Fri (3 emails per week)
- Add new BCC contacts: sukhan@alphabold.com, fatima.umer15@gmail.com, ajbutt48@gmail.com
- Update GitHub Actions workflow name and cron schedule (0 4 * * 1,3,5)
- Modify template selection: Monday (Template 1), Wednesday (Template 3), Friday (Template 2)
- Update local scheduling to include Wednesday at 9:00 AM PKT
- Remove random template selection for a consistent weekly pattern
- Update all documentation references to reflect the new 3-day schedule
- Add hssn.wasim3334@gmail.com as AVG Phase 1 Resident & Colleague
- Add descriptive comments for existing BCC contacts (Secondary Test Email, Outlook Test Email)
- Improve contact organization and documentation in the BCC_EMAILS list
- Maintain existing contact structure while adding new community members